### PR TITLE
1.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 
 [![Release](https://jitpack.io/v/io.github.sportstalk247/sdk-android-kotlin.svg)](https://jitpack.io/#io.github.sportstalk247/sdk-android-kotlin)
-[![Maven Central](https://img.shields.io/maven-central/v/io.github.sportstalk247/sdk-coroutine-android?label=Maven%20Central)](https://search.maven.org/artifact/io.github.sportstalk247/sdk-coroutine-android)
+[![Maven Central](https://img.shields.io/maven-central/v/io.github.sportstalk247/sdk-android-kotlin?label=Maven%20Central)](https://search.maven.org/artifact/io.github.sportstalk247/sdk-android-kotlin)
 
 # sdk-android-kotlin
 
@@ -30,8 +30,11 @@ For Groovy:
 ```groovy
 allprojects {
     repositories {
-    // ...
-       mavenCentral()   // Make sure that Maven Central is declared
+        // ...
+       mavenCentral()
+       maven {
+          url "https://s01.oss.sonatype.org/content/repositories/snapshots/"
+       }
        maven {
           url "https://jitpack.io"
        }
@@ -43,7 +46,8 @@ For Kotlin DSL:
 allprojects {
     repositories { 
        // ...
-       mavenCentral()   // Make sure that Maven Central is declared
+       mavenCentral()
+       maven("https://s01.oss.sonatype.org/content/repositories/snapshots/")
        maven("https://jitpack.io")
        // ...
     }
@@ -70,7 +74,7 @@ implementation("io.github.sportstalk247:sdk-android-kotlin:sdk-reactive-rx2:X.Y.
 ```
 
 [![Release](https://jitpack.io/v/io.github.sportstalk247/sdk-android-kotlin.svg)](https://jitpack.io/#io.github.sportstalk247/sdk-android-kotlin)
-[![Maven Central](https://img.shields.io/maven-central/v/io.github.sportstalk247/sdk-coroutine-android?label=Maven%20Central)](https://search.maven.org/artifact/io.github.sportstalk247/sdk-coroutine-android)
+[![Maven Central](https://img.shields.io/maven-central/v/io.github.sportstalk247/sdk-android-kotlin?label=Maven%20Central)](https://search.maven.org/artifact/io.github.sportstalk247/sdk-android-kotlin)
 
 Then sync again. The gradle build should now be successful.
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 
-[![Release](https://jitpack.io/v/com.github.sportstalk247/sdk-android-kotlin.svg)](https://jitpack.io/#com.github.sportstalk247/sdk-android-kotlin)
+[![Release](https://jitpack.io/v/io.github.sportstalk247/sdk-android-kotlin.svg)](https://jitpack.io/#io.github.sportstalk247/sdk-android-kotlin)
+[![Maven Central](https://img.shields.io/maven-central/v/io.github.sportstalk247/sdk-coroutine-android?label=Maven%20Central)](https://search.maven.org/artifact/io.github.sportstalk247/sdk-coroutine-android)
 
 # sdk-android-kotlin
 
@@ -30,6 +31,7 @@ For Groovy:
 allprojects {
     repositories {
     // ...
+       mavenCentral()   // Make sure that Maven Central is declared
        maven {
           url "https://jitpack.io"
        }
@@ -41,6 +43,7 @@ For Kotlin DSL:
 allprojects {
     repositories { 
        // ...
+       mavenCentral()   // Make sure that Maven Central is declared
        maven("https://jitpack.io")
        // ...
     }
@@ -52,21 +55,22 @@ allprojects {
 For Groovy:
 ```groovy
 // For SDK coroutine implementation
-implementation 'com.github.sportstalk247:sdk-android-kotlin:sdk-coroutine:X.Y.Z'
+implementation 'io.github.sportstalk247:sdk-android-kotlin:sdk-coroutine:X.Y.Z'
 // OR
 // For SDK Rx2Java implementation
-implementation 'com.github.sportstalk247:sdk-android-kotlin:sdk-reactive-rx2:X.Y.Z'
+implementation 'io.github.sportstalk247:sdk-android-kotlin:sdk-reactive-rx2:X.Y.Z'
 ```
 For Kotlin DSL:
 ```groovy
 // For SDK coroutine implementation
-implementation("com.github.sportstalk247:sdk-android-kotlin:sdk-coroutine:X.Y.Z")
+implementation("io.github.sportstalk247:sdk-android-kotlin:sdk-coroutine:X.Y.Z")
 // OR
 // For SDK Rx2Java implementation
-implementation("com.github.sportstalk247:sdk-android-kotlin:sdk-reactive-rx2:X.Y.Z")
+implementation("io.github.sportstalk247:sdk-android-kotlin:sdk-reactive-rx2:X.Y.Z")
 ```
 
-[![Release](https://jitpack.io/v/com.github.sportstalk247/sdk-android-kotlin.svg)](https://jitpack.io/#com.github.sportstalk247/sdk-android-kotlin)
+[![Release](https://jitpack.io/v/io.github.sportstalk247/sdk-android-kotlin.svg)](https://jitpack.io/#io.github.sportstalk247/sdk-android-kotlin)
+[![Maven Central](https://img.shields.io/maven-central/v/io.github.sportstalk247/sdk-coroutine-android?label=Maven%20Central)](https://search.maven.org/artifact/io.github.sportstalk247/sdk-coroutine-android)
 
 Then sync again. The gradle build should now be successful.
 
@@ -80,8 +84,8 @@ From:
 ```
 To:
 ```kotlin
-implementation("com.github.sportstalk247:sdk-android-kotlin:sdk-coroutine:X.Y.Z")
-implementation("com.github.sportstalk247:sdk-android-kotlin:sdk-reactive-rx2:X.Y.Z")
+implementation("io.github.sportstalk247:sdk-android-kotlin:sdk-coroutine:X.Y.Z")
+implementation("io.github.sportstalk247:sdk-android-kotlin:sdk-reactive-rx2:X.Y.Z")
 ```
 
 There are significant dependency updates made on version `1.3.0`. Notable changes are as follows:

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,7 @@
 import java.io.FileInputStream
 import java.util.Properties
 
-val packageGroup by extra { "io.github.sportstalk247" }
+val packageGroup by extra { "io.github.sportstalk247.${rootProject.name}" }
 val packageVersion by extra { "1.3.0" }
 
 // https://youtrack.jetbrains.com/issue/KTIJ-19369
@@ -39,9 +39,6 @@ allprojects {
         extensions.findByType<PublishingExtension>()?.apply {
 
             publications.withType<MavenPublication>().configureEach {
-
-                // "sdk-coroutine-android", "sdk-reactive-rx2-android"
-                artifactId = "${artifactId}-android"
 
                 artifact(emptyJavadocJar.get())
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,7 @@
 import java.io.FileInputStream
 import java.util.Properties
 
-val packageGroup by extra { "com.github.sportstalk247.sdk-android-kotlin" }
+val packageGroup by extra { "io.github.sportstalk247" }
 val packageVersion by extra { "1.3.0" }
 
 // https://youtrack.jetbrains.com/issue/KTIJ-19369
@@ -39,6 +39,9 @@ allprojects {
         extensions.findByType<PublishingExtension>()?.apply {
 
             publications.withType<MavenPublication>().configureEach {
+
+                // "sdk-coroutine-android", "sdk-reactive-rx2-android"
+                artifactId = "${artifactId}-android"
 
                 artifact(emptyJavadocJar.get())
 

--- a/docs/source/usage/how_to_download_the_sdk.md
+++ b/docs/source/usage/how_to_download_the_sdk.md
@@ -44,10 +44,10 @@ In order to use it in your application, just do the following:
         // ...
         dependencies {
             // For SDK coroutine implementation
-            implementation 'io.github.sportstalk247:sdk-coroutine-android:X.Y.Z'
+            implementation 'io.github.sportstalk247.sdk-android-kotlin:sdk-coroutine:X.Y.Z'
             // OR
             // For SDK Rx2Java implementation
-            implementation 'io.github.sportstalk247:sdk-reactive-rx2-android:X.Y.Z'
+            implementation 'io.github.sportstalk247.sdk-android-kotlin:sdk-reactive-rx2:X.Y.Z'
         }
         // ...
 
@@ -56,16 +56,16 @@ In order to use it in your application, just do the following:
         // ...
         dependencies {
             // For SDK coroutine implementation
-            implementation("io.github.sportstalk247:sdk-coroutine-android:X.Y.Z")
+            implementation("io.github.sportstalk247.sdk-android-kotlin:sdk-coroutine:X.Y.Z")
             // OR
             // For SDK Rx2Java implementation
-            implementation("io.github.sportstalk247:sdk-reactive-rx2-android:X.Y.Z")
+            implementation("io.github.sportstalk247.sdk-android-kotlin:sdk-reactive-rx2:X.Y.Z")
         }
         // ...
         
 ```
 
 [![Release](https://jitpack.io/v/io.github.sportstalk247/sdk-android-kotlin.svg)](https://jitpack.io/#io.github.sportstalk247/sdk-android-kotlin)
-[![Maven Central](https://img.shields.io/maven-central/v/io.github.sportstalk247/sdk-coroutine-android?label=Maven%20Central)](https://search.maven.org/artifact/io.github.sportstalk247/sdk-coroutine-android)
+[![Maven Central](https://img.shields.io/maven-central/v/io.github.sportstalk247/sdk-android-kotlin?label=Maven%20Central)](https://search.maven.org/artifact/io.github.sportstalk247/sdk-android-kotlin)
 
 Then sync again. The gradle build should now be successful.

--- a/docs/source/usage/how_to_download_the_sdk.md
+++ b/docs/source/usage/how_to_download_the_sdk.md
@@ -44,10 +44,10 @@ In order to use it in your application, just do the following:
         // ...
         dependencies {
             // For SDK coroutine implementation
-            implementation 'com.github.sportstalk247.sdk-android-kotlin:sdk-coroutine:X.Y.Z'
+            implementation 'io.github.sportstalk247:sdk-coroutine-android:X.Y.Z'
             // OR
             // For SDK Rx2Java implementation
-            implementation 'com.github.sportstalk247.sdk-android-kotlin:sdk-reactive-rx2:X.Y.Z'
+            implementation 'io.github.sportstalk247:sdk-reactive-rx2-android:X.Y.Z'
         }
         // ...
 
@@ -56,15 +56,16 @@ In order to use it in your application, just do the following:
         // ...
         dependencies {
             // For SDK coroutine implementation
-            implementation("com.github.sportstalk247.sdk-android-kotlin:sdk-coroutine:X.Y.Z")
+            implementation("io.github.sportstalk247:sdk-coroutine-android:X.Y.Z")
             // OR
             // For SDK Rx2Java implementation
-            implementation("com.github.sportstalk247.sdk-android-kotlin:sdk-reactive-rx2:X.Y.Z")
+            implementation("io.github.sportstalk247:sdk-reactive-rx2-android:X.Y.Z")
         }
         // ...
         
 ```
 
-[![Release](https://jitpack.io/v/com.github.sportstalk247/sdk-android-kotlin.svg)](https://jitpack.io/#com.github.sportstalk247/sdk-android-kotlin)
+[![Release](https://jitpack.io/v/io.github.sportstalk247/sdk-android-kotlin.svg)](https://jitpack.io/#io.github.sportstalk247/sdk-android-kotlin)
+[![Maven Central](https://img.shields.io/maven-central/v/io.github.sportstalk247/sdk-coroutine-android?label=Maven%20Central)](https://search.maven.org/artifact/io.github.sportstalk247/sdk-coroutine-android)
 
 Then sync again. The gradle build should now be successful.

--- a/sdk-coroutine/README.md
+++ b/sdk-coroutine/README.md
@@ -1,16 +1,18 @@
 
-[![Release](https://jitpack.io/v/com.github.sportstalk247/sdk-android-kotlin.svg)](https://jitpack.io/#com.github.sportstalk247/sdk-android-kotlin)
+[![Release](https://jitpack.io/v/io.github.sportstalk247/sdk-android-kotlin.svg)](https://jitpack.io/#io.github.sportstalk247/sdk-android-kotlin)
+[![Maven Central](https://img.shields.io/maven-central/v/io.github.sportstalk247/sdk-coroutine-android?label=Maven%20Central)](https://search.maven.org/artifact/io.github.sportstalk247/sdk-coroutine-android)
 
 # sdk-coroutine
 
 ```groovy
-implementation 'com.github.sportstalk247.sdk-android-kotlin:sdk-coroutine:X.Y.Z'
+implementation 'io.github.sportstalk247:sdk-coroutine-android:X.Y.Z'
 ```
 ```kotlin
-implementation 'com.github.sportstalk247.sdk-android-kotlin:sdk-coroutine:X.Y.Z'
+implementation 'io.github.sportstalk247:sdk-coroutine-android:X.Y.Z'
 ```
 
-[![Release](https://jitpack.io/v/com.github.sportstalk247/sdk-android-kotlin.svg)](https://jitpack.io/#com.github.sportstalk247/sdk-android-kotlin)
+[![Release](https://jitpack.io/v/io.github.sportstalk247/sdk-android-kotlin.svg)](https://jitpack.io/#io.github.sportstalk247/sdk-android-kotlin)
+[![Maven Central](https://img.shields.io/maven-central/v/io.github.sportstalk247/sdk-coroutine-android?label=Maven%20Central)](https://search.maven.org/artifact/io.github.sportstalk247/sdk-coroutine-android)
 
 # How to Use
 

--- a/sdk-coroutine/README.md
+++ b/sdk-coroutine/README.md
@@ -1,18 +1,18 @@
 
 [![Release](https://jitpack.io/v/io.github.sportstalk247/sdk-android-kotlin.svg)](https://jitpack.io/#io.github.sportstalk247/sdk-android-kotlin)
-[![Maven Central](https://img.shields.io/maven-central/v/io.github.sportstalk247/sdk-coroutine-android?label=Maven%20Central)](https://search.maven.org/artifact/io.github.sportstalk247/sdk-coroutine-android)
+[![Maven Central](https://img.shields.io/maven-central/v/io.github.sportstalk247/sdk-android-kotlin?label=Maven%20Central)](https://search.maven.org/artifact/io.github.sportstalk247/sdk-android-kotlin)
 
 # sdk-coroutine
 
 ```groovy
-implementation 'io.github.sportstalk247:sdk-coroutine-android:X.Y.Z'
+implementation 'io.github.sportstalk247.sdk-android-kotlin:sdk-coroutine:X.Y.Z'
 ```
 ```kotlin
-implementation 'io.github.sportstalk247:sdk-coroutine-android:X.Y.Z'
+implementation 'io.github.sportstalk247.sdk-android-kotlin:sdk-coroutine:X.Y.Z'
 ```
 
 [![Release](https://jitpack.io/v/io.github.sportstalk247/sdk-android-kotlin.svg)](https://jitpack.io/#io.github.sportstalk247/sdk-android-kotlin)
-[![Maven Central](https://img.shields.io/maven-central/v/io.github.sportstalk247/sdk-coroutine-android?label=Maven%20Central)](https://search.maven.org/artifact/io.github.sportstalk247/sdk-coroutine-android)
+[![Maven Central](https://img.shields.io/maven-central/v/io.github.sportstalk247/sdk-android-kotlin?label=Maven%20Central)](https://search.maven.org/artifact/io.github.sportstalk247/sdk-android-kotlin)
 
 # How to Use
 

--- a/sdk-reactive-rx2/README.md
+++ b/sdk-reactive-rx2/README.md
@@ -1,14 +1,14 @@
 [![Release](https://jitpack.io/v/io.github.sportstalk247/sdk-android-kotlin.svg)](https://jitpack.io/#io.github.sportstalk247/sdk-android-kotlin)
-[![Maven Central](https://img.shields.io/maven-central/v/io.github.sportstalk247/sdk-coroutine-android?label=Maven%20Central)](https://search.maven.org/artifact/io.github.sportstalk247/sdk-coroutine-android)
+[![Maven Central](https://img.shields.io/maven-central/v/io.github.sportstalk247/sdk-android-kotlin?label=Maven%20Central)](https://search.maven.org/artifact/io.github.sportstalk247/sdk-android-kotlin)
 
 # sdk-reactive-rx2
 
 ```groovy
-implementation 'io.github.sportstalk247:sdk-android-kotlin:sdk-reactive-rx2:X.Y.Z'
+implementation 'io.github.sportstalk247.sdk-android-kotlin:sdk-reactive-rx2:X.Y.Z'
 ```
 
 [![Release](https://jitpack.io/v/io.github.sportstalk247/sdk-android-kotlin.svg)](https://jitpack.io/#io.github.sportstalk247/sdk-android-kotlin)
-[![Maven Central](https://img.shields.io/maven-central/v/io.github.sportstalk247/sdk-coroutine-android?label=Maven%20Central)](https://search.maven.org/artifact/io.github.sportstalk247/sdk-coroutine-android)
+[![Maven Central](https://img.shields.io/maven-central/v/io.github.sportstalk247/sdk-android-kotlin?label=Maven%20Central)](https://search.maven.org/artifact/io.github.sportstalk247/sdk-android-kotlin)
 
 # How to Use
 

--- a/sdk-reactive-rx2/README.md
+++ b/sdk-reactive-rx2/README.md
@@ -1,12 +1,14 @@
-[![Release](https://jitpack.io/v/com.github.sportstalk247/sdk-android-kotlin.svg)](https://jitpack.io/#com.github.sportstalk247/sdk-android-kotlin)
+[![Release](https://jitpack.io/v/io.github.sportstalk247/sdk-android-kotlin.svg)](https://jitpack.io/#io.github.sportstalk247/sdk-android-kotlin)
+[![Maven Central](https://img.shields.io/maven-central/v/io.github.sportstalk247/sdk-coroutine-android?label=Maven%20Central)](https://search.maven.org/artifact/io.github.sportstalk247/sdk-coroutine-android)
 
 # sdk-reactive-rx2
 
 ```groovy
-implementation 'com.github.sportstalk247:sdk-android-kotlin:sdk-reactive-rx2:X.Y.Z'
+implementation 'io.github.sportstalk247:sdk-android-kotlin:sdk-reactive-rx2:X.Y.Z'
 ```
 
-[![Release](https://jitpack.io/v/com.github.sportstalk247/sdk-android-kotlin.svg)](https://jitpack.io/#com.github.sportstalk247/sdk-android-kotlin)
+[![Release](https://jitpack.io/v/io.github.sportstalk247/sdk-android-kotlin.svg)](https://jitpack.io/#io.github.sportstalk247/sdk-android-kotlin)
+[![Maven Central](https://img.shields.io/maven-central/v/io.github.sportstalk247/sdk-coroutine-android?label=Maven%20Central)](https://search.maven.org/artifact/io.github.sportstalk247/sdk-coroutine-android)
 
 # How to Use
 


### PR DESCRIPTION
* Update library versions and setup nexus plugin publish script
* Update read-the-docs documentation
* Update README.md to include migration guide to version 1.3.0
* Sportstalk Android SDK is now published on Maven Central and will continue to get published here moving forward. 



